### PR TITLE
Refactor editor page into modular components and hooks

### DIFF
--- a/app/editor/[id]/components/ChatPanel.tsx
+++ b/app/editor/[id]/components/ChatPanel.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+import { Resizable } from "re-resizable";
+import type { ChatMessage, User } from "../types";
+import { colorFromString } from "../utils/colorHelpers";
+
+interface ChatPanelProps {
+  chatMessages: ChatMessage[];
+  user: User | null;
+  onSendMessage: (message: ChatMessage) => void;
+  onClose: () => void;
+}
+
+export function ChatPanel({
+  chatMessages,
+  user,
+  onSendMessage,
+  onClose,
+}: ChatPanelProps) {
+  const [newMessage, setNewMessage] = useState("");
+
+  function sendChat() {
+    if (!newMessage.trim() || !user) return;
+    const payload: ChatMessage = {
+      senderEmail: user.email,
+      senderUsername: user.username ?? user.email,
+      message: newMessage.trim(),
+      timestamp: Date.now(),
+    };
+    onSendMessage(payload);
+    setNewMessage("");
+  }
+
+  return (
+    <Resizable
+      defaultSize={{ width: 320 }}
+      minWidth={220}
+      maxWidth={600}
+      enable={{ left: true }}
+    >
+      <aside className="h-full bg-gray-800 p-4 border-l border-gray-700 flex flex-col">
+        <div className="flex justify-between items-center mb-2">
+          <h3 className="text-lg font-semibold">Chat</h3>
+          <button
+            className="text-gray-400 hover:text-gray-200"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto mb-2 space-y-3">
+          {chatMessages.map((m, i) => (
+            <div key={i} className="text-sm">
+              <div className="flex items-center gap-2">
+                <div
+                  style={{
+                    width: 10,
+                    height: 10,
+                    background: colorFromString(m.senderEmail),
+                    borderRadius: 3,
+                  }}
+                />
+                <div className="font-semibold text-xs text-blue-300">
+                  {m.senderUsername ?? m.senderEmail}
+                </div>
+                <div className="text-xs text-gray-500 ml-auto">
+                  {new Date(m.timestamp).toLocaleTimeString()}
+                </div>
+              </div>
+              <div className="ml-4">{m.message}</div>
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <input
+            className="flex-1 p-2 rounded bg-gray-700 text-white"
+            value={newMessage}
+            onChange={(e) => setNewMessage(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && sendChat()}
+            placeholder="Type a message..."
+          />
+          <button onClick={sendChat} className="bg-blue-700 px-3 rounded">
+            Send
+          </button>
+        </div>
+      </aside>
+    </Resizable>
+  );
+}

--- a/app/editor/[id]/components/FileTree.tsx
+++ b/app/editor/[id]/components/FileTree.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import {
+  VscChevronDown,
+  VscChevronRight,
+  VscFile,
+  VscFolder,
+  VscFolderOpened,
+  VscNewFile,
+  VscNewFolder,
+  VscTrash,
+} from "react-icons/vsc";
+import type { FileNode } from "../types";
+
+interface FileTreeProps {
+  fileTree: FileNode[];
+  setFileTree: React.Dispatch<React.SetStateAction<FileNode[]>>;
+  activeFile: string;
+  setActiveFile: (file: string) => void;
+  expandedFolders: Set<string>;
+  setExpandedFolders: React.Dispatch<React.SetStateAction<Set<string>>>;
+  onAddNode: (type: "file" | "folder", parentPath: string) => void;
+  onDeleteNode: (path: string) => void;
+}
+
+export function FileTree({
+  fileTree,
+  activeFile,
+  setActiveFile,
+  expandedFolders,
+  setExpandedFolders,
+  onAddNode,
+  onDeleteNode,
+}: FileTreeProps) {
+  function renderTree(nodes: FileNode[], base = "") {
+    return nodes.map((node) => {
+      const path = base ? `${base}/${node.name}` : node.name;
+      if (node.type === "folder") {
+        const isExpanded = expandedFolders.has(path);
+        return (
+          <div key={path} className="pl-2">
+            <div
+              className="cursor-pointer flex items-center gap-2 px-2 py-1 hover:bg-gray-700 rounded select-none"
+              onClick={() => {
+                const n = new Set(expandedFolders);
+                if (n.has(path)) {
+                  n.delete(path);
+                } else {
+                  n.add(path);
+                }
+                setExpandedFolders(n);
+              }}
+            >
+              {isExpanded ? <VscChevronDown /> : <VscChevronRight />}
+              {isExpanded ? <VscFolderOpened /> : <VscFolder />}
+              <span className="truncate">{node.name}</span>
+              <div className="ml-auto flex gap-1">
+                <button
+                  className="text-gray-400 hover:text-gray-200"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAddNode("file", path);
+                  }}
+                >
+                  <VscNewFile />
+                </button>
+                <button
+                  className="text-gray-400 hover:text-gray-200"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAddNode("folder", path);
+                  }}
+                >
+                  <VscNewFolder />
+                </button>
+                {path !== "root" && (
+                  <button
+                    className="text-gray-400 hover:text-red-500"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDeleteNode(path);
+                    }}
+                  >
+                    <VscTrash />
+                  </button>
+                )}
+              </div>
+            </div>
+            {isExpanded && node.children && (
+              <div className="pl-6 border-l border-gray-700 ml-2">
+                {renderTree(node.children, path)}
+              </div>
+            )}
+          </div>
+        );
+      }
+      return (
+        <div
+          key={path}
+          className={`cursor-pointer flex items-center gap-2 px-2 py-1 rounded text-sm select-none ${
+            activeFile === path
+              ? "bg-gray-700 text-white"
+              : "hover:bg-gray-700 text-gray-300"
+          }`}
+          onClick={() => setActiveFile(path)}
+        >
+          <VscFile />
+          <span className="truncate">{node.name}</span>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDeleteNode(path);
+            }}
+            className="ml-auto text-gray-400 hover:text-red-500"
+          >
+            <VscTrash />
+          </button>
+        </div>
+      );
+    });
+  }
+
+  return <div>{renderTree(fileTree)}</div>;
+}

--- a/app/editor/[id]/components/PresenceList.tsx
+++ b/app/editor/[id]/components/PresenceList.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import type { PresenceUser } from "../types";
+
+interface PresenceListProps {
+  presence: PresenceUser[];
+}
+
+export function PresenceList({ presence }: PresenceListProps) {
+  return (
+    <div className="mt-6">
+      <h4 className="text-sm font-medium mb-2">Active</h4>
+      <div className="space-y-2">
+        {presence.map((p) => (
+          <div key={p.clientId} className="flex items-center gap-2">
+            <span
+              style={{
+                width: 10,
+                height: 10,
+                background: p.user?.color ?? "#888",
+                borderRadius: 3,
+              }}
+            />
+            <div>
+              <div className="font-medium text-sm">
+                {p.user?.name ?? p.user?.email ?? "unknown"}
+              </div>
+              <div className="text-xs text-gray-400">
+                {p.cursor
+                  ? `Line ${p.cursor.line}, Col ${p.cursor.column}`
+                  : ""}
+              </div>
+            </div>
+          </div>
+        ))}
+        {presence.length === 0 && (
+          <div className="text-xs text-gray-400">No collaborators yet</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/editor/[id]/hooks/useFileTree.ts
+++ b/app/editor/[id]/hooks/useFileTree.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import type { FileNode } from "../types";
+import { findFirstFile } from "../utils/fileTreeHelpers";
+
+export function useFileTree(projectId: string) {
+  const [fileTree, setFileTree] = useState<FileNode[]>([]);
+  const [filesContent, setFilesContent] = useState<Record<string, string>>({});
+  const [projectTitle, setProjectTitle] = useState("Loading...");
+
+  useEffect(() => {
+    if (!projectId) return;
+
+    fetch(`/api/projects/${projectId}`)
+      .then((r) => r.json())
+      .then((data) => {
+        const root: FileNode = data.structure ?? data;
+        setProjectTitle(data.title ?? "Untitled");
+
+        const flat: Record<string, string> = {};
+        function walk(node: FileNode, path = "") {
+          const cur = path ? `${path}/${node.name}` : node.name;
+          if (node.type === "file") flat[cur] = node.content ?? "";
+          else node.children?.forEach((c) => walk(c, cur));
+        }
+        walk(root);
+
+        setFilesContent(flat);
+        setFileTree([root]);
+      })
+      .catch(console.error);
+  }, [projectId]);
+
+  const updateFileContent = (path: string, content: string) => {
+    setFilesContent((prev) => ({ ...prev, [path]: content }));
+  };
+
+  const getFirstFile = () => findFirstFile(fileTree);
+
+  return {
+    fileTree,
+    setFileTree,
+    filesContent,
+    setFilesContent,
+    updateFileContent,
+    projectTitle,
+    getFirstFile,
+  };
+}

--- a/app/editor/[id]/hooks/useFileTree.ts
+++ b/app/editor/[id]/hooks/useFileTree.ts
@@ -13,11 +13,11 @@ export function useFileTree(projectId: string) {
     fetch(`/api/projects/${projectId}`)
       .then((r) => r.json())
       .then((data) => {
-        const root: FileNode = data.structure ?? data;
+        const root = data.structure ?? data;
         setProjectTitle(data.title ?? "Untitled");
 
         const flat: Record<string, string> = {};
-        function walk(node: FileNode, path = "") {
+        function walk(node: FileNode & { content?: string }, path = "") {
           const cur = path ? `${path}/${node.name}` : node.name;
           if (node.type === "file") flat[cur] = node.content ?? "";
           else node.children?.forEach((c) => walk(c, cur));

--- a/app/editor/[id]/hooks/useFileTree.ts
+++ b/app/editor/[id]/hooks/useFileTree.ts
@@ -30,10 +30,6 @@ export function useFileTree(projectId: string) {
       .catch(console.error);
   }, [projectId]);
 
-  const updateFileContent = (path: string, content: string) => {
-    setFilesContent((prev) => ({ ...prev, [path]: content }));
-  };
-
   const getFirstFile = () => findFirstFile(fileTree);
 
   return {
@@ -41,7 +37,6 @@ export function useFileTree(projectId: string) {
     setFileTree,
     filesContent,
     setFilesContent,
-    updateFileContent,
     projectTitle,
     getFirstFile,
   };

--- a/app/editor/[id]/hooks/useFileTree.ts
+++ b/app/editor/[id]/hooks/useFileTree.ts
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { FileNode } from "../types";
 import { findFirstFile } from "../utils/fileTreeHelpers";
 
 export function useFileTree(projectId: string) {
   const [fileTree, setFileTree] = useState<FileNode[]>([]);
-  const [filesContent, setFilesContent] = useState<Record<string, string>>({});
+  const [initialFiles, setInitialFiles] = useState<Record<string, string>>({});
+  const filesRef = useRef<Record<string, string>>({});
   const [projectTitle, setProjectTitle] = useState("Loading...");
 
   useEffect(() => {
@@ -24,7 +25,8 @@ export function useFileTree(projectId: string) {
         }
         walk(root);
 
-        setFilesContent(flat);
+        setInitialFiles(flat);
+        filesRef.current = flat;
         setFileTree([root]);
       })
       .catch(console.error);
@@ -35,8 +37,8 @@ export function useFileTree(projectId: string) {
   return {
     fileTree,
     setFileTree,
-    filesContent,
-    setFilesContent,
+    initialFiles,
+    filesRef,
     projectTitle,
     getFirstFile,
   };

--- a/app/editor/[id]/hooks/useMonaco.ts
+++ b/app/editor/[id]/hooks/useMonaco.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-export function useMonacoSetup() {
+export function useMonaco() {
   useEffect(() => {
     if (typeof window === "undefined") return;
 

--- a/app/editor/[id]/hooks/useSocket.ts
+++ b/app/editor/[id]/hooks/useSocket.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from "react";
+import io from "socket.io-client";
+import type {
+  ChatMessage,
+  NodeAddedPayload,
+  NodeDeletedPayload,
+} from "../types";
+
+export function useSocket(projectId: string) {
+  const socketRef = useRef<SocketIOClient.Socket | null>(null);
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
+
+  useEffect(() => {
+    if (!projectId) return;
+
+    const s = io("http://localhost:3001");
+    socketRef.current = s;
+    s.emit("join-doc", projectId);
+
+    s.on("chat-history", (msgs: ChatMessage[]) => setChatMessages(msgs));
+    s.on("chat-message", (m: ChatMessage) => setChatMessages((p) => [...p, m]));
+
+    return () => {
+      s.disconnect();
+      socketRef.current = null;
+    };
+  }, [projectId]);
+
+  const emitNodeAdded = (payload: NodeAddedPayload) => {
+    socketRef.current?.emit("node-added", payload);
+  };
+
+  const emitNodeDeleted = (payload: NodeDeletedPayload) => {
+    socketRef.current?.emit("node-deleted", payload);
+  };
+
+  const emitChatMessage = (message: ChatMessage) => {
+    socketRef.current?.emit("chat-message", message);
+  };
+
+  return {
+    socket: socketRef.current,
+    chatMessages,
+    emitNodeAdded,
+    emitNodeDeleted,
+    emitChatMessage,
+  };
+}

--- a/app/editor/[id]/hooks/useUser.ts
+++ b/app/editor/[id]/hooks/useUser.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import type { User } from "../types";
+
+export function useUser(): User | null {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const raw = localStorage.getItem("user");
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw);
+        setUser({
+          email: parsed.email,
+          username: parsed.username || parsed.email,
+        });
+      } catch {
+        setUser({ email: "anonymous@local" });
+      }
+    } else {
+      setUser({ email: "anonymous@local" });
+    }
+  }, []);
+
+  return user;
+}

--- a/app/editor/[id]/hooks/useYjs.ts
+++ b/app/editor/[id]/hooks/useYjs.ts
@@ -11,7 +11,6 @@ export function useYjs(
   user: User | null,
   projectId: string,
   filesContent: Record<string, string>,
-  updateFileContent: (path: string, content: string) => void,
 ) {
   const [monaco, setMonaco] = useState<typeof import("monaco-editor") | null>(
     null,
@@ -180,21 +179,7 @@ export function useYjs(
       });
     });
 
-    const modelListener = model.onDidChangeContent(() => {
-      try {
-        const text = model.getValue();
-        if (text !== filesContent[activeFile]) {
-          updateFileContent(activeFile, text);
-        }
-      } catch (e) {
-        console.error("Failed to update file content", e);
-      }
-    });
-
     return () => {
-      try {
-        modelListener.dispose();
-      } catch {}
       try {
         cursorListener?.dispose();
       } catch {}
@@ -208,7 +193,6 @@ export function useYjs(
     projectId,
     updateRemoteCursorDecorations,
     filesContent,
-    updateFileContent,
     provider,
     editor,
     model,

--- a/app/editor/[id]/hooks/useYjs.ts
+++ b/app/editor/[id]/hooks/useYjs.ts
@@ -141,13 +141,8 @@ export function useYjs(
         const isInitialized = ymap!.get("initialized");
         const hasContent = ytext!.length > 0;
 
-        if (
-          !isInitialized &&
-          !hasContent &&
-          activeFile &&
-          initialFiles[activeFile]
-        ) {
-          ytext!.insert(0, initialFiles[activeFile]);
+        if (!isInitialized && !hasContent && activeFile && files[activeFile]) {
+          ytext!.insert(0, files[activeFile]);
           ymap!.set("initialized", true);
         }
       };

--- a/app/editor/[id]/hooks/useYjs.ts
+++ b/app/editor/[id]/hooks/useYjs.ts
@@ -186,8 +186,8 @@ export function useYjs(
         if (text !== filesContent[activeFile]) {
           updateFileContent(activeFile, text);
         }
-      } catch {
-        console.error();
+      } catch (e) {
+        console.error("Failed to update file content", e);
       }
     });
 

--- a/app/editor/[id]/hooks/useYjs.ts
+++ b/app/editor/[id]/hooks/useYjs.ts
@@ -1,0 +1,222 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as Y from "yjs";
+import { WebsocketProvider } from "y-websocket";
+import type * as Monaco from "monaco-editor";
+import type { MonacoBinding } from "y-monaco";
+import { randomColor } from "../utils/colorHelpers";
+import type { PresenceUser, User } from "../types";
+
+export function useYjs(
+  activeFile: string,
+  user: User | null,
+  projectId: string,
+  filesContent: Record<string, string>,
+  updateFileContent: (path: string, content: string) => void,
+) {
+  const [monaco, setMonaco] = useState<typeof import("monaco-editor") | null>(
+    null,
+  );
+  const [editor, setEditor] =
+    useState<Monaco.editor.IStandaloneCodeEditor | null>(null);
+  const [model, setModel] = useState<Monaco.editor.ITextModel | null>(null);
+  const [ydoc, setYdoc] = useState<Y.Doc | null>(null);
+  const [provider, setProvider] = useState<WebsocketProvider | null>(null);
+
+  const [presence, setPresence] = useState<PresenceUser[]>([]);
+
+  const decorationsRef = useRef<string[]>([]);
+
+  const updateRemoteCursorDecorations = useCallback(
+    (states: PresenceUser[]) => {
+      if (!provider || !editor || !monaco) return;
+      const myClientId = provider.awareness.clientID;
+      const decs: Monaco.editor.IModelDeltaDecoration[] = [];
+
+      states.forEach((s) => {
+        if (!s.cursor || s.clientId === myClientId) return;
+        const line = s.cursor.line ?? 1;
+        const col = s.cursor.column ?? 1;
+        decs.push({
+          range: new monaco.Range(line, col, line, col),
+          options: {
+            className: undefined,
+            isWholeLine: false,
+            stickiness:
+              monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+            hoverMessage: {
+              value: `**${s.user?.name ?? s.user?.email ?? "user"}**`,
+            },
+            inlineClassName: `remoteCursor_${s.clientId}`,
+          },
+        });
+      });
+
+      decorationsRef.current = editor.deltaDecorations(
+        decorationsRef.current,
+        decs,
+      );
+
+      // CSS for remote cursors
+      const styleId = "remote-cursors-styles";
+      let styleEl = document.getElementById(styleId) as HTMLStyleElement | null;
+      if (!styleEl) {
+        styleEl = document.createElement("style");
+        styleEl.id = styleId;
+        document.head.appendChild(styleEl);
+      }
+      styleEl.innerHTML = states
+        .map((s) => {
+          if (!s.user) return "";
+          const color = s.user.color ?? "#888";
+          return `.monaco-editor .remoteCursor_${s.clientId} { background: rgba(${parseInt(color.slice(1, 3), 16)}, ${parseInt(color.slice(3, 5), 16)}, ${parseInt(color.slice(5, 7), 16)}, 0.12); border-left: 2px solid ${color}; }`;
+        })
+        .join("\n");
+    },
+    [editor, monaco, provider],
+  );
+
+  // Create Y.Doc
+  useEffect(() => {
+    const doc = new Y.Doc();
+    setYdoc(doc);
+    return () => {
+      try {
+        doc.destroy?.();
+      } catch {}
+    };
+  }, [activeFile, projectId]);
+
+  // Connect to Yjs server
+  useEffect(() => {
+    if (!ydoc) return;
+    const safeFile = activeFile.replace(/[\/\\]/g, "--").replace(/\./g, "-");
+    const docName = `${projectId}-${safeFile}`;
+    const provider = new WebsocketProvider(
+      "ws://localhost:1234",
+      docName,
+      ydoc,
+    );
+    setProvider(provider);
+
+    return () => {
+      provider?.destroy?.();
+    };
+  }, [activeFile, projectId, ydoc]);
+
+  // Setup model for the active file
+  useEffect(() => {
+    if (!activeFile || !monaco) return;
+
+    const safeFile = activeFile.replace(/[\/\\]/g, "--").replace(/\./g, "-");
+
+    const uri = monaco.Uri.parse(`inmemory:///${projectId}/${safeFile}`);
+    let model = monaco.editor.getModel(uri);
+    if (!model) {
+      model = monaco.editor.createModel(
+        filesContent[activeFile] ?? "",
+        "javascript",
+        uri,
+      );
+    }
+
+    setModel(model);
+  }, [activeFile, monaco, projectId, filesContent]);
+
+  // Update editor with the new model
+  useEffect(() => {
+    if (!editor || !model) return;
+    editor.setModel(model);
+  }, [editor, model]);
+
+  // Setup monaco binding
+  useEffect(() => {
+    let binding: MonacoBinding | undefined;
+    import("y-monaco").then(({ MonacoBinding }) => {
+      if (!ydoc || !model || !provider) return;
+      const ytext = ydoc.getText("monaco");
+      binding = new MonacoBinding(
+        ytext,
+        model,
+        editor ? new Set([editor]) : new Set(),
+        provider.awareness,
+      );
+    });
+
+    return () => {
+      binding?.destroy?.();
+    };
+  }, [model, provider, ydoc, editor]);
+
+  // Awareness setup
+  useEffect(() => {
+    if (!provider || !editor || !model) return;
+    const awareness = provider.awareness;
+    if (user) {
+      awareness.setLocalStateField("user", {
+        name: user.username ?? user.email ?? "unknown",
+        email: user.email,
+        color: randomColor(),
+        cursor: null,
+      });
+    }
+
+    const onAwarenessChange = () => {
+      const states = Array.from(awareness.getStates().entries()).map(
+        ([clientId, state]) => ({
+          clientId: Number(clientId),
+          user: state?.user,
+          cursor: state?.cursor,
+        }),
+      );
+      setPresence(states);
+      updateRemoteCursorDecorations(states);
+    };
+    awareness.on("change", onAwarenessChange);
+
+    const cursorListener = editor.onDidChangeCursorPosition((e) => {
+      awareness.setLocalStateField("cursor", {
+        line: e.position.lineNumber,
+        column: e.position.column,
+      });
+    });
+
+    const modelListener = model.onDidChangeContent(() => {
+      try {
+        const text = model.getValue();
+        if (text !== filesContent[activeFile]) {
+          updateFileContent(activeFile, text);
+        }
+      } catch {
+        console.error();
+      }
+    });
+
+    return () => {
+      try {
+        modelListener.dispose();
+      } catch {}
+      try {
+        cursorListener?.dispose();
+      } catch {}
+      try {
+        awareness.off("change", onAwarenessChange);
+      } catch {}
+    };
+  }, [
+    activeFile,
+    user,
+    projectId,
+    updateRemoteCursorDecorations,
+    filesContent,
+    updateFileContent,
+    provider,
+    editor,
+    model,
+  ]);
+
+  return {
+    presence,
+    setEditor,
+    setMonaco,
+  };
+}

--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -43,7 +43,6 @@ export default function EditorPage() {
     setFileTree,
     filesContent,
     setFilesContent,
-    updateFileContent,
     projectTitle,
     getFirstFile,
   } = useFileTree(projectId);
@@ -60,7 +59,6 @@ export default function EditorPage() {
     user,
     projectId,
     filesContent,
-    updateFileContent,
   );
 
   useEffect(() => {

--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -1,645 +1,215 @@
 "use client";
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import Editor, { OnMount } from "@monaco-editor/react";
-import type * as Monaco from "monaco-editor";
-import * as Y from "yjs";
-import { WebsocketProvider } from "y-websocket";
-import io from "socket.io-client";
-import type { Socket } from "socket.io-client";
 import { useParams } from "next/navigation";
-import { Resizable } from "re-resizable";
-import {
-  VscChevronDown,
-  VscChevronRight,
-  VscFile,
-  VscFolder,
-  VscFolderOpened,
-  VscNewFile,
-  VscNewFolder,
-  VscTrash,
-  VscComment,
-} from "react-icons/vsc";
+import { VscComment } from "react-icons/vsc";
 
-type FileNode = {
-  name: string;
-  type: "file" | "folder";
-  children?: FileNode[];
-  content?: string | null;
-};
-type ChatMessage = {
-  senderEmail: string;
-  senderUsername: string;
-  message: string;
-  timestamp: number;
-};
-type NodeAddedPayload = {
-  type: "file" | "folder";
-  parentPath: string;
-  name: string;
-};
-type NodeDeletedPayload = { path: string };
+import type {
+  ChatMessage,
+  NodeAddedPayload,
+  NodeDeletedPayload,
+} from "./types";
+
+import { useUser } from "./hooks/useUser";
+import { useSocket } from "./hooks/useSocket";
+import { useFileTree } from "./hooks/useFileTree";
+import { useYjs } from "./hooks/useYjs";
+
+import { useMonacoSetup } from "./utils/monacoSetup";
+import { addNode, deleteNode, reconstructTree } from "./utils/fileTreeHelpers";
+
+import { FileTree } from "./components/FileTree";
+import { ChatPanel } from "./components/ChatPanel";
+import { PresenceList } from "./components/PresenceList";
 
 export default function EditorPage() {
   const { id: projectId } = useParams() as { id: string };
 
-  const monacoRef = useRef<typeof import("monaco-editor") | null>(null);
-  const editorRef = useRef<Monaco.editor.IStandaloneCodeEditor | null>(null);
-  const modelRef = useRef<Monaco.editor.ITextModel | null>(null);
-  const ydocRef = useRef<Y.Doc | null>(null);
-  const providerRef = useRef<WebsocketProvider | null>(null);
-  const monacoBindingRef = useRef<any | null>(null);
+  useMonacoSetup();
 
-  const socketRef = useRef<typeof Socket | null>(null);
+  const user = useUser();
 
-  const [fileTree, setFileTree] = useState<FileNode[]>([]);
-  const [filesContent, setFilesContent] = useState<Record<string, string>>({});
+  const {
+    socket,
+    chatMessages,
+    emitNodeAdded,
+    emitNodeDeleted,
+    emitChatMessage,
+  } = useSocket(projectId);
+
+  const {
+    fileTree,
+    setFileTree,
+    filesContent,
+    setFilesContent,
+    updateFileContent,
+    projectTitle,
+    getFirstFile,
+  } = useFileTree(projectId);
+
   const [activeFile, setActiveFile] = useState<string>("");
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
     new Set(),
   );
-  const [projectTitle, setProjectTitle] = useState("Loading...");
+
   const [chatOpen, setChatOpen] = useState(false);
-  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
-  const [newMessage, setNewMessage] = useState("");
-  const [presence, setPresence] = useState<
-    {
-      clientId: number;
-      user?: { name?: string; email?: string; color?: string };
-      cursor?: { line: number; column: number };
-    }[]
-  >([]);
-  const [user, setUser] = useState<{ email: string; username?: string } | null>(
-    null,
+
+  const { presence, setEditor, setMonaco } = useYjs(
+    activeFile,
+    user,
+    projectId,
+    filesContent,
+    updateFileContent,
   );
 
-  // ---------- Monaco worker ----------
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    type MonacoEnv = {
-      MonacoEnvironment?: {
-        getWorker?: (moduleId: string, label: string) => Worker;
-      };
-    };
-    (window as MonacoEnv).MonacoEnvironment =
-      (window as MonacoEnv).MonacoEnvironment || {};
-    ((window as MonacoEnv).MonacoEnvironment as any).getWorker = function (
-      moduleId: string,
-      label: string,
-    ) {
-      if (label === "json")
-        return new Worker(
-          new URL(
-            "monaco-editor/esm/vs/language/json/json.worker",
-            import.meta.url,
-          ),
-          { type: "module" },
-        );
-      if (label === "css" || label === "scss" || label === "less")
-        return new Worker(
-          new URL(
-            "monaco-editor/esm/vs/language/css/css.worker",
-            import.meta.url,
-          ),
-          { type: "module" },
-        );
-      if (label === "html" || label === "handlebars" || label === "razor")
-        return new Worker(
-          new URL(
-            "monaco-editor/esm/vs/language/html/html.worker",
-            import.meta.url,
-          ),
-          { type: "module" },
-        );
-      if (label === "typescript" || label === "javascript")
-        return new Worker(
-          new URL(
-            "monaco-editor/esm/vs/language/typescript/ts.worker",
-            import.meta.url,
-          ),
-          { type: "module" },
-        );
-      return new Worker(
-        new URL("monaco-editor/esm/vs/editor/editor.worker", import.meta.url),
-        { type: "module" },
-      );
-    };
-  }, []);
-
-  // ---------- load logged-in user ----------
-  useEffect(() => {
-    const raw = localStorage.getItem("user");
-    if (raw) {
-      try {
-        const parsed = JSON.parse(raw);
-        setUser({
-          email: parsed.email,
-          username: parsed.username || parsed.email,
-        });
-      } catch {
-        setUser({ email: "anonymous@local" });
+    if (fileTree.length > 0 && !activeFile) {
+      const firstFile = getFirstFile();
+      if (firstFile) {
+        setActiveFile(firstFile);
+        setExpandedFolders(new Set([fileTree[0].name]));
       }
-    } else setUser({ email: "anonymous@local" });
-  }, []);
+    }
+  }, [fileTree, activeFile, getFirstFile]);
 
-  // ---------- socket.io (chat + tree only) ----------
   useEffect(() => {
-    if (!projectId) return;
-    const s = io("http://localhost:3001");
-    socketRef.current = s;
-    s.emit("join-doc", projectId);
+    if (!socket) return;
 
-    s.on("chat-history", (msgs: ChatMessage[]) => setChatMessages(msgs));
-    s.on("chat-message", (m: ChatMessage) => setChatMessages((p) => [...p, m]));
-    s.on("node-added", (payload: NodeAddedPayload) => {
+    const handleNodeAdded = (payload: NodeAddedPayload) => {
       setFileTree((prev) =>
         addNode(prev, payload, (full) =>
           setFilesContent((p) => ({ ...p, [full]: "" })),
         ),
       );
       setExpandedFolders((p) => new Set(p).add(payload.parentPath));
-    });
-    s.on("node-deleted", (payload: NodeDeletedPayload) => {
+    };
+
+    const handleNodeDeleted = (payload: NodeDeletedPayload) => {
       if (payload.path === "root") return;
-      setFileTree((prev) => deleteNode(prev, payload.path));
+      setFileTree((prev) => deleteNode(prev, payload));
       setFilesContent((prev) => {
         const c = { ...prev };
         delete c[payload.path];
         return c;
       });
-    });
+    };
+
+    socket.on("node-added", handleNodeAdded);
+    socket.on("node-deleted", handleNodeDeleted);
 
     return () => {
-      s.disconnect();
-      socketRef.current = null;
+      socket.off("node-added", handleNodeAdded);
+      socket.off("node-deleted", handleNodeDeleted);
     };
-  }, [projectId]);
+  }, [socket, setFileTree, setFilesContent]);
 
-  // ---------- load project ----------
-  useEffect(() => {
-    if (!projectId) return;
-    fetch(`/api/projects/${projectId}`)
-      .then((r) => r.json())
-      .then((data) => {
-        const root: FileNode = data.structure ?? data;
-        setProjectTitle(data.title ?? "Untitled");
-        const flat: Record<string, string> = {};
-        function walk(node: FileNode, path = "") {
-          const cur = path ? `${path}/${node.name}` : node.name;
-          if (node.type === "file") flat[cur] = node.content ?? "";
-          else node.children?.forEach((c) => walk(c, cur));
-        }
-        walk(root);
-        setFilesContent(flat);
-        setFileTree([root]);
-        const firstFile = Object.keys(flat)[0];
-        if (firstFile) setActiveFile(firstFile);
-        setExpandedFolders(new Set([root.name]));
-      })
-      .catch(console.error);
-  }, [projectId]);
-
-  // ---------- utils ----------
-  function colorFromString(s: string) {
-    let h = 0;
-    for (let i = 0; i < s.length; i++) h = (h << 5) - h + s.charCodeAt(i);
-    const hex = ((h >>> 0) & 0xffffff).toString(16).padStart(6, "0");
-    return `#${hex}`;
-  }
-  function hexToRgba(hex: string, alpha = 0.2) {
-    const h = hex.replace("#", "");
-    const bigint = parseInt(h, 16);
-    const r = (bigint >> 16) & 255;
-    const g = (bigint >> 8) & 255;
-    const b = bigint & 255;
-    return `rgba(${r},${g},${b},${alpha})`;
-  }
-
-  // ---------- remote cursors ----------
-  const decorationsRef = useRef<string[]>([]);
-  const updateRemoteCursorDecorations = useCallback(
-    (
-      states: {
-        clientId: number;
-        user?: { name?: string; email?: string; color?: string };
-        cursor?: { line: number; column: number };
-      }[],
-    ) => {
-      if (!editorRef.current || !monacoRef.current) return;
-      const m = monacoRef.current;
-      const editor = editorRef.current;
-      const myClientId = providerRef.current?.awareness?.clientID;
-      const decs: Monaco.editor.IModelDeltaDecoration[] = [];
-      states.forEach((s) => {
-        if (!s.cursor || s.clientId === myClientId) return;
-        const line = s.cursor.line ?? 1;
-        const col = s.cursor.column ?? 1;
-        decs.push({
-          range: new m.Range(line, col, line, col),
-          options: {
-            className: undefined,
-            isWholeLine: false,
-            stickiness:
-              m.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-            hoverMessage: {
-              value: `**${s.user?.name ?? s.user?.email ?? "user"}**`,
-            },
-            inlineClassName: `remoteCursor_${s.clientId}`,
-          },
-        });
-      });
-      decorationsRef.current = editor.deltaDecorations(
-        decorationsRef.current,
-        decs,
-      );
-
-      // CSS for remote cursors
-      const styleId = "remote-cursors-styles";
-      let styleEl = document.getElementById(styleId) as HTMLStyleElement | null;
-      if (!styleEl) {
-        styleEl = document.createElement("style");
-        styleEl.id = styleId;
-        document.head.appendChild(styleEl);
-      }
-      styleEl.innerHTML = states
-        .map((s) => {
-          if (!s.user) return "";
-          const color =
-            s.user.color ??
-            colorFromString(s.user.email ?? s.user.name ?? "unknown");
-          return `.monaco-editor .remoteCursor_${s.clientId} { background: ${hexToRgba(color, 0.12)}; border-left: 2px solid ${color}; }`;
-        })
-        .join("\n");
-    },
-    [],
-  );
-
-  // ---------- Yjs + Monaco binding ----------
-  useEffect(() => {
-    if (!activeFile || !user || !editorRef.current || !monacoRef.current)
-      return;
-
-    let cleanup: (() => void) | null = null;
-    let destroyed = false;
-
-    async function setupYjsForFile() {
-      // destroy previous objects
-      if (monacoBindingRef.current) {
-        try {
-          monacoBindingRef.current.destroy?.();
-        } catch {}
-        monacoBindingRef.current = null;
-      }
-      if (providerRef.current) {
-        try {
-          providerRef.current.destroy?.();
-        } catch {}
-        providerRef.current = null;
-      }
-      if (ydocRef.current) {
-        try {
-          ydocRef.current.destroy?.();
-        } catch {}
-        ydocRef.current = null;
-      }
-
-      const ydoc = new Y.Doc();
-      ydocRef.current = ydoc;
-      const safeFile = activeFile.replace(/[\/\\]/g, "--").replace(/\./g, "-");
-      const docName = `${projectId}-${safeFile}`;
-      const provider = new WebsocketProvider(
-        "ws://localhost:1234",
-        docName,
-        ydoc,
-      );
-      providerRef.current = provider;
-
-      const m = monacoRef.current!;
-      const uri = m.Uri.parse(`inmemory:///${projectId}/${safeFile}`);
-      let model = m.editor.getModel(uri);
-      if (!model)
-        model = m.editor.createModel(
-          filesContent[activeFile] ?? "",
-          "javascript",
-          uri,
-        );
-      modelRef.current = model;
-      if (editorRef.current) {
-        editorRef.current.setModel(model);
-      }
-
-      const ytext = ydoc.getText("monaco");
-      const { MonacoBinding } = await import("y-monaco");
-      const binding = new MonacoBinding(
-        ytext,
-        model,
-        new Set([editorRef.current!].filter(Boolean)),
-        provider.awareness,
-      );
-      monacoBindingRef.current = binding;
-
-      // Awareness setup
-      const awareness = provider.awareness;
-      function randomColor() {
-        const colors = ["#ff6b6b", "#6bc1ff", "#51d88a", "#fbbf24", "#9b5de5"];
-        return colors[Math.floor(Math.random() * colors.length)];
-      }
-      if (user) {
-        awareness.setLocalStateField("user", {
-          name: user.username ?? user.email ?? "unknown",
-          email: user.email,
-          color: randomColor(),
-          cursor: null,
-        });
-      }
-
-      const onAwarenessChange = () => {
-        const states = Array.from(awareness.getStates().entries()).map(
-          ([clientId, state]: any) => ({
-            clientId: Number(clientId),
-            user: state?.user,
-            cursor: state?.cursor,
-          }),
-        );
-        setPresence(states);
-        updateRemoteCursorDecorations(states);
-      };
-      awareness.on("change", onAwarenessChange);
-
-      const cursorListener = editorRef.current?.onDidChangeCursorPosition(
-        (e) => {
-          awareness.setLocalStateField("cursor", {
-            line: e.position.lineNumber,
-            column: e.position.column,
-          });
-        },
-      );
-
-      const modelListener = model.onDidChangeContent(() => {
-        try {
-          const text = model.getValue();
-          setFilesContent((p) => ({ ...p, [activeFile]: text }));
-        } catch {}
-      });
-
-      onAwarenessChange();
-
-      cleanup = () => {
-        if (destroyed) return;
-        destroyed = true;
-        try {
-          modelListener.dispose();
-        } catch {}
-        try {
-          cursorListener?.dispose();
-        } catch {}
-        try {
-          awareness.off("change", onAwarenessChange);
-        } catch {}
-        try {
-          binding.destroy?.();
-        } catch {}
-        try {
-          provider.destroy?.();
-        } catch {}
-        try {
-          ydoc.destroy?.();
-        } catch {}
-      };
-    }
-
-    setupYjsForFile();
-    return () => {
-      if (cleanup) cleanup();
-    };
-  }, [activeFile, user, projectId, updateRemoteCursorDecorations]);
-
-  // ---------- file tree helpers ----------
-  function addNode(
-    tree: FileNode[],
-    payload: NodeAddedPayload,
-    onFileInit?: (full: string) => void,
-  ) {
-    const { type, parentPath, name } = payload;
-    const newTree = JSON.parse(JSON.stringify(tree)) as FileNode[];
-    function walk(nodes: FileNode[], curPath: string): boolean {
-      for (const node of nodes) {
-        const nodePath = curPath ? `${curPath}/${node.name}` : node.name;
-        if (nodePath === parentPath) {
-          if (!node.children) node.children = [];
-          if (type === "file") {
-            node.children.push({ name, type: "file", content: "" });
-            onFileInit?.(`${nodePath}/${name}`);
-          } else node.children.push({ name, type: "folder", children: [] });
-          return true;
-        }
-        if (node.children && walk(node.children, nodePath)) return true;
-      }
-      return false;
-    }
-    walk(newTree, "");
-    return newTree;
-  }
-
-  function deleteNode(tree: FileNode[], path: string) {
-    const newTree = JSON.parse(JSON.stringify(tree)) as FileNode[];
-    function walk(nodes: FileNode[], curPath: string) {
-      return nodes.filter((node) => {
-        const nodePath = curPath ? `${curPath}/${node.name}` : node.name;
-        if (nodePath === path) return false;
-        if (node.children) node.children = walk(node.children, nodePath);
-        return true;
-      });
-    }
-    return walk(newTree, "");
-  }
-
-  function handleSaveProject() {
+  const handleSaveProject = useCallback(() => {
     if (!projectId) return;
     const structure = reconstructTree(fileTree)[0];
     fetch(`/api/projects/${projectId}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ structure }),
-    }).then((res) => {
-      if (res.ok) alert("Project saved");
-      else alert("Save failed");
-    });
-  }
+    })
+      .then((res) => {
+        if (res.ok) alert("Project saved");
+        else alert("Save failed");
+      })
+      .catch(() => alert("Save failed"));
+  }, [projectId, fileTree]);
 
-  function reconstructTree(nodes: FileNode[], base = ""): FileNode[] {
-    return nodes.map((n) => {
-      const path = base ? `${base}/${n.name}` : n.name;
-      if (n.type === "folder")
-        return {
-          name: n.name,
-          type: "folder",
-          children: n.children ? reconstructTree(n.children, path) : [],
-        };
-      return { name: n.name, type: "file", content: filesContent[path] || "" };
-    });
-  }
+  const handleAddNode = useCallback(
+    (type: "file" | "folder", parentPath: string) => {
+      const name = prompt(`Enter ${type} name`);
+      if (!name) return;
+      setFileTree((p) =>
+        addNode(p, { type, parentPath, name }, (full) =>
+          setFilesContent((s) => ({ ...s, [full]: "" })),
+        ),
+      );
+      setExpandedFolders((p) => new Set(p).add(parentPath));
+      emitNodeAdded({ type, parentPath, name });
+    },
+    [setFileTree, setFilesContent, emitNodeAdded],
+  );
 
-  function handleDelete(path: string) {
-    if (path === "root") return alert("Root cannot be deleted.");
-    if (!confirm(`Delete ${path}?`)) return;
-    setFileTree((p) => deleteNode(p, path));
-    socketRef.current?.emit("node-deleted", { path });
-    setFilesContent((prev) => {
-      const copy = { ...prev };
-      delete copy[path];
-      return copy;
-    });
-  }
+  const handleDeleteNode = useCallback(
+    (path: string) => {
+      if (path === "root") return alert("Root cannot be deleted.");
+      if (!confirm(`Delete ${path}?`)) return;
+      setFileTree((p) => deleteNode(p, { path }));
+      emitNodeDeleted({ path });
+      setFilesContent((prev) => {
+        const copy = { ...prev };
+        delete copy[path];
+        return copy;
+      });
+    },
+    [setFileTree, emitNodeDeleted, setFilesContent],
+  );
 
-  function promptAdd(type: "file" | "folder", parentPath: string) {
-    const name = prompt(`Enter ${type} name`);
-    if (!name) return;
-    setFileTree((p) =>
-      addNode(p, { type, parentPath, name }, (full) =>
-        setFilesContent((s) => ({ ...s, [full]: "" })),
-      ),
-    );
-    setExpandedFolders((p) => new Set(p).add(parentPath));
-    socketRef.current?.emit("node-added", { type, parentPath, name });
-  }
+  const handleSendChatMessage = useCallback(
+    (message: ChatMessage) => {
+      fetch(`/api/projects/${projectId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(message),
+      }).catch(console.error);
+      emitChatMessage(message);
+    },
+    [projectId, emitChatMessage],
+  );
 
-  // ---------- render file tree ----------
-  function renderTree(nodes: FileNode[], base = "") {
-    return nodes.map((node) => {
-      const path = base ? `${base}/${node.name}` : node.name;
-      if (node.type === "folder") {
-        const isExpanded = expandedFolders.has(path);
-        return (
-          <div key={path} className="pl-2">
-            <div
-              className="cursor-pointer flex items-center gap-2 px-2 py-1 hover:bg-gray-700 rounded select-none"
-              onClick={() => {
-                const n = new Set(expandedFolders);
-                n.has(path) ? n.delete(path) : n.add(path);
-                setExpandedFolders(n);
-              }}
-            >
-              {isExpanded ? <VscChevronDown /> : <VscChevronRight />}
-              {isExpanded ? <VscFolderOpened /> : <VscFolder />}
-              <span className="truncate">{node.name}</span>
-              <div className="ml-auto flex gap-1">
-                <button
-                  className="text-gray-400 hover:text-gray-200"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    promptAdd("file", path);
-                  }}
-                >
-                  <VscNewFile />
-                </button>
-                <button
-                  className="text-gray-400 hover:text-gray-200"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    promptAdd("folder", path);
-                  }}
-                >
-                  <VscNewFolder />
-                </button>
-                {path !== "root" && (
-                  <button
-                    className="text-gray-400 hover:text-red-500"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDelete(path);
-                    }}
-                  >
-                    <VscTrash />
-                  </button>
-                )}
-              </div>
-            </div>
-            {isExpanded && node.children && (
-              <div className="pl-6 border-l border-gray-700 ml-2">
-                {renderTree(node.children, path)}
-              </div>
-            )}
-          </div>
+  const handleMount: OnMount = useCallback(
+    (editor, monaco) => {
+      setEditor(editor);
+      setMonaco(monaco);
+      if (!activeFile) return;
+      const safe = activeFile.replace(/[\/\\]/g, "--").replace(/\./g, "-");
+      const uri = monaco.Uri.parse(`inmemory:///${projectId}/${safe}`);
+      let model = monaco.editor.getModel(uri);
+      if (!model)
+        model = monaco.editor.createModel(
+          filesContent[activeFile] ?? "",
+          "javascript",
+          uri,
         );
-      }
-      return (
-        <div
-          key={path}
-          className={`cursor-pointer flex items-center gap-2 px-2 py-1 rounded text-sm select-none ${activeFile === path ? "bg-gray-700 text-white" : "hover:bg-gray-700 text-gray-300"}`}
-          onClick={() => setActiveFile(path)}
-        >
-          <VscFile />
-          <span className="truncate">{node.name}</span>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              handleDelete(path);
-            }}
-            className="ml-auto text-gray-400 hover:text-red-500"
-          >
-            <VscTrash />
-          </button>
-        </div>
-      );
-    });
-  }
+      editor.setModel(model);
+    },
+    [activeFile, projectId, filesContent, setEditor, setMonaco],
+  );
 
-  // ---------- editor mount ----------
-  const handleMount: OnMount = (editor, monaco) => {
-    editorRef.current = editor;
-    monacoRef.current = monaco;
-    if (!activeFile) return;
-    const safe = activeFile.replace(/[\/\\]/g, "--").replace(/\./g, "-");
-    const uri = monaco.Uri.parse(`inmemory:///${projectId}/${safe}`);
-    let model = monaco.editor.getModel(uri);
-    if (!model)
-      model = monaco.editor.createModel(
-        filesContent[activeFile] ?? "",
-        "javascript",
-        uri,
-      );
-    modelRef.current = model;
-    editor.setModel(model);
-  };
-
-  function sendChat() {
-    if (!newMessage.trim() || !user) return;
-    const payload: ChatMessage = {
-      senderEmail: user.email,
-      senderUsername: user.username ?? user.email,
-      message: newMessage.trim(),
-      timestamp: Date.now(),
-    };
-    fetch(`/api/projects/${projectId}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-    }).catch(console.error);
-    socketRef.current?.emit("chat-message", payload);
-    setNewMessage("");
-  }
-
-  // ---------- JSX ----------
   return (
     <div className="flex h-screen bg-gray-900 text-gray-200">
       <aside
-        className={`w-64 bg-gray-800 p-4 overflow-y-auto text-sm border-r border-gray-700 ${chatOpen ? "hidden md:block" : ""}`}
+        className={`w-64 bg-gray-800 p-4 overflow-y-auto text-sm border-r border-gray-700 ${
+          chatOpen ? "hidden md:block" : ""
+        }`}
       >
         <h2 className="text-xl font-bold mb-4 border-b border-gray-700 pb-2">
           {projectTitle}
         </h2>
-        <div>{renderTree(fileTree)}</div>
+        <FileTree
+          fileTree={fileTree}
+          setFileTree={setFileTree}
+          activeFile={activeFile}
+          setActiveFile={setActiveFile}
+          expandedFolders={expandedFolders}
+          setExpandedFolders={setExpandedFolders}
+          onAddNode={handleAddNode}
+          onDeleteNode={handleDeleteNode}
+        />
         <div className="mt-4 flex gap-2">
           <button
             className="flex-1 bg-blue-800 hover:bg-blue-700 py-1 rounded"
-            onClick={() => promptAdd("folder", "root")}
+            onClick={() => handleAddNode("folder", "root")}
           >
             + Folder
           </button>
           <button
             className="flex-1 bg-blue-800 hover:bg-blue-700 py-1 rounded"
-            onClick={() => promptAdd("file", "root")}
+            onClick={() => handleAddNode("file", "root")}
           >
             + File
           </button>
@@ -650,36 +220,7 @@ export default function EditorPage() {
         >
           <VscComment /> Chat
         </button>
-        <div className="mt-6">
-          <h4 className="text-sm font-medium mb-2">Active</h4>
-          <div className="space-y-2">
-            {presence.map((p) => (
-              <div key={p.clientId} className="flex items-center gap-2">
-                <span
-                  style={{
-                    width: 10,
-                    height: 10,
-                    background: p.user?.color ?? "#888",
-                    borderRadius: 3,
-                  }}
-                />
-                <div>
-                  <div className="font-medium text-sm">
-                    {p.user?.name ?? p.user?.email ?? "unknown"}
-                  </div>
-                  <div className="text-xs text-gray-400">
-                    {p.cursor
-                      ? `Line ${p.cursor.line}, Col ${p.cursor.column}`
-                      : ""}
-                  </div>
-                </div>
-              </div>
-            ))}
-            {presence.length === 0 && (
-              <div className="text-xs text-gray-400">No collaborators yet</div>
-            )}
-          </div>
-        </div>
+        <PresenceList presence={presence} />
       </aside>
 
       <div
@@ -710,58 +251,12 @@ export default function EditorPage() {
       </div>
 
       {chatOpen && (
-        <Resizable
-          defaultSize={{ width: 320 }}
-          minWidth={220}
-          maxWidth={600}
-          enable={{ left: true }}
-        >
-          <aside className="h-full bg-gray-800 p-4 border-l border-gray-700 flex flex-col">
-            <div className="flex justify-between items-center mb-2">
-              <h3 className="text-lg font-semibold">Chat</h3>
-              <button
-                className="text-gray-400 hover:text-gray-200"
-                onClick={() => setChatOpen(false)}
-              >
-                Close
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto mb-2 space-y-3">
-              {chatMessages.map((m, i) => (
-                <div key={i} className="text-sm">
-                  <div className="flex items-center gap-2">
-                    <div
-                      style={{
-                        width: 10,
-                        height: 10,
-                        background: colorFromString(m.senderEmail),
-                        borderRadius: 3,
-                      }}
-                    />
-                    <div className="font-semibold text-xs text-blue-300">
-                      {m.senderUsername ?? m.senderEmail}
-                    </div>
-                    <div className="text-xs text-gray-500 ml-auto">
-                      {new Date(m.timestamp).toLocaleTimeString()}
-                    </div>
-                  </div>
-                  <div className="ml-4">{m.message}</div>
-                </div>
-              ))}
-            </div>
-            <div className="flex gap-2">
-              <input
-                className="flex-1 p-2 rounded bg-gray-700 text-white"
-                value={newMessage}
-                onChange={(e) => setNewMessage(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && sendChat()}
-              />
-              <button onClick={sendChat} className="bg-blue-700 px-3 rounded">
-                Send
-              </button>
-            </div>
-          </aside>
-        </Resizable>
+        <ChatPanel
+          chatMessages={chatMessages}
+          user={user}
+          onSendMessage={handleSendChatMessage}
+          onClose={() => setChatOpen(false)}
+        />
       )}
     </div>
   );

--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import React, { useCallback, useEffect, useState, useRef } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import Editor, { OnMount } from "@monaco-editor/react";
 import { useParams } from "next/navigation";
 import { VscComment } from "react-icons/vsc";
-import * as monaco from "monaco-editor";
 
 import type {
   ChatMessage,
@@ -28,6 +27,7 @@ export default function EditorPage() {
   const { id: projectId } = useParams() as { id: string };
 
   useMonacoSetup();
+
   const user = useUser();
 
   const {
@@ -52,6 +52,7 @@ export default function EditorPage() {
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
     new Set(),
   );
+
   const [chatOpen, setChatOpen] = useState(false);
 
   const { presence, setEditor, setMonaco } = useYjs(
@@ -61,10 +62,6 @@ export default function EditorPage() {
     filesContent,
     updateFileContent,
   );
-
-  // 🔑 NEW refs to keep editor & monaco instances
-  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
-  const monacoRef = useRef<typeof import("monaco-editor") | null>(null);
 
   useEffect(() => {
     if (fileTree.length > 0 && !activeFile) {
@@ -164,34 +161,24 @@ export default function EditorPage() {
     [projectId, emitChatMessage],
   );
 
-  // 🔑 Simplified: just save the refs
-  const handleMount: OnMount = (editor, monaco) => {
-    setEditor(editor);
-    setMonaco(monaco);
-    editorRef.current = editor;
-    monacoRef.current = monaco;
-  };
-
-  // 🔑 NEW effect to update Monaco model when content changes
-  useEffect(() => {
-    if (!editorRef.current || !monacoRef.current || !activeFile) return;
-
-    const monaco = monacoRef.current;
-    const safe = activeFile.replace(/[\/\\]/g, "--").replace(/\./g, "-");
-    const uri = monaco.Uri.parse(`inmemory:///${projectId}/${safe}`);
-    let model = monaco.editor.getModel(uri);
-
-    if (!model) {
-      model = monaco.editor.createModel(
-        filesContent[activeFile] ?? "",
-        "javascript",
-        uri,
-      );
-    } else if (model.getValue() !== (filesContent[activeFile] ?? "")) {
-      model.setValue(filesContent[activeFile] ?? "");
-    }
-    editorRef.current.setModel(model);
-  }, [activeFile, filesContent, projectId]);
+  const handleMount: OnMount = useCallback(
+    (editor, monaco) => {
+      setEditor(editor);
+      setMonaco(monaco);
+      if (!activeFile) return;
+      const safe = activeFile.replace(/[\/\\]/g, "--").replace(/\./g, "-");
+      const uri = monaco.Uri.parse(`inmemory:///${projectId}/${safe}`);
+      let model = monaco.editor.getModel(uri);
+      if (!model)
+        model = monaco.editor.createModel(
+          filesContent[activeFile] ?? "",
+          "javascript",
+          uri,
+        );
+      editor.setModel(model);
+    },
+    [activeFile, projectId, filesContent, setEditor, setMonaco],
+  );
 
   return (
     <div className="flex h-screen bg-gray-900 text-gray-200">

--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -163,19 +163,8 @@ export default function EditorPage() {
     (editor, monaco) => {
       setEditor(editor);
       setMonaco(monaco);
-      if (!activeFile) return;
-      const safe = activeFile.replace(/[\/\\]/g, "--").replace(/\./g, "-");
-      const uri = monaco.Uri.parse(`inmemory:///${projectId}/${safe}`);
-      let model = monaco.editor.getModel(uri);
-      if (!model)
-        model = monaco.editor.createModel(
-          filesContent[activeFile] ?? "",
-          "javascript",
-          uri,
-        );
-      editor.setModel(model);
     },
-    [activeFile, projectId, filesContent, setEditor, setMonaco],
+    [setEditor, setMonaco],
   );
 
   return (

--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -106,7 +106,7 @@ export default function EditorPage() {
 
   const handleSaveProject = useCallback(() => {
     if (!projectId) return;
-    const structure = reconstructTree(fileTree)[0];
+    const structure = reconstructTree(fileTree, "", filesContent)[0];
     fetch(`/api/projects/${projectId}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -117,7 +117,7 @@ export default function EditorPage() {
         else alert("Save failed");
       })
       .catch(() => alert("Save failed"));
-  }, [projectId, fileTree]);
+  }, [projectId, fileTree, filesContent]);
 
   const handleAddNode = useCallback(
     (type: "file" | "folder", parentPath: string) => {

--- a/app/editor/[id]/page.tsx
+++ b/app/editor/[id]/page.tsx
@@ -16,7 +16,7 @@ import { useSocket } from "./hooks/useSocket";
 import { useFileTree } from "./hooks/useFileTree";
 import { useYjs } from "./hooks/useYjs";
 
-import { useMonacoSetup } from "./utils/monacoSetup";
+import { useMonaco } from "./hooks/useMonaco";
 import { addNode, deleteNode, reconstructTree } from "./utils/fileTreeHelpers";
 
 import { FileTree } from "./components/FileTree";
@@ -26,7 +26,7 @@ import { PresenceList } from "./components/PresenceList";
 export default function EditorPage() {
   const { id: projectId } = useParams() as { id: string };
 
-  useMonacoSetup();
+  useMonaco();
 
   const user = useUser();
 

--- a/app/editor/[id]/types/index.ts
+++ b/app/editor/[id]/types/index.ts
@@ -2,7 +2,6 @@ export type FileNode = {
   name: string;
   type: "file" | "folder";
   children?: FileNode[];
-  content?: string | null;
 };
 
 export type ChatMessage = {

--- a/app/editor/[id]/types/index.ts
+++ b/app/editor/[id]/types/index.ts
@@ -1,0 +1,32 @@
+export type FileNode = {
+  name: string;
+  type: "file" | "folder";
+  children?: FileNode[];
+  content?: string | null;
+};
+
+export type ChatMessage = {
+  senderEmail: string;
+  senderUsername: string;
+  message: string;
+  timestamp: number;
+};
+
+export type NodeAddedPayload = {
+  type: "file" | "folder";
+  parentPath: string;
+  name: string;
+};
+
+export type NodeDeletedPayload = { path: string };
+
+export type User = {
+  email: string;
+  username?: string;
+};
+
+export type PresenceUser = {
+  clientId: number;
+  user?: { name?: string; email?: string; color?: string };
+  cursor?: { line: number; column: number };
+};

--- a/app/editor/[id]/utils/colorHelpers.ts
+++ b/app/editor/[id]/utils/colorHelpers.ts
@@ -1,0 +1,20 @@
+export function colorFromString(s: string): string {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h << 5) - h + s.charCodeAt(i);
+  const hex = ((h >>> 0) & 0xffffff).toString(16).padStart(6, "0");
+  return `#${hex}`;
+}
+
+export function hexToRgba(hex: string, alpha = 0.2): string {
+  const h = hex.replace("#", "");
+  const bigint = parseInt(h, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+export function randomColor(): string {
+  const colors = ["#ff6b6b", "#6bc1ff", "#51d88a", "#fbbf24", "#9b5de5"];
+  return colors[Math.floor(Math.random() * colors.length)];
+}

--- a/app/editor/[id]/utils/fileTreeHelpers.ts
+++ b/app/editor/[id]/utils/fileTreeHelpers.ts
@@ -68,7 +68,7 @@ export function reconstructTree(
     return {
       name: n.name,
       type: "file",
-      content: n.content || filesContent[path] || "",
+      content: filesContent[path] || "",
     };
   });
 }

--- a/app/editor/[id]/utils/fileTreeHelpers.ts
+++ b/app/editor/[id]/utils/fileTreeHelpers.ts
@@ -1,0 +1,82 @@
+import type { FileNode, NodeAddedPayload, NodeDeletedPayload } from "../types";
+
+export function addNode(
+  tree: FileNode[],
+  payload: NodeAddedPayload,
+  onFileInit?: (full: string) => void,
+): FileNode[] {
+  const { type, parentPath, name } = payload;
+  const newTree = JSON.parse(JSON.stringify(tree)) as FileNode[];
+
+  function walk(nodes: FileNode[], curPath: string): boolean {
+    for (const node of nodes) {
+      const nodePath = curPath ? `${curPath}/${node.name}` : node.name;
+      if (nodePath === parentPath) {
+        if (!node.children) node.children = [];
+        if (type === "file") {
+          node.children.push({ name, type: "file", content: "" });
+          onFileInit?.(`${nodePath}/${name}`);
+        } else {
+          node.children.push({ name, type: "folder", children: [] });
+        }
+        return true;
+      }
+      if (node.children && walk(node.children, nodePath)) return true;
+    }
+    return false;
+  }
+
+  walk(newTree, "");
+  return newTree;
+}
+
+export function deleteNode(
+  tree: FileNode[],
+  payload: NodeDeletedPayload,
+): FileNode[] {
+  const { path } = payload;
+  const newTree = JSON.parse(JSON.stringify(tree)) as FileNode[];
+
+  function walk(nodes: FileNode[], curPath: string): FileNode[] {
+    return nodes.filter((node) => {
+      const nodePath = curPath ? `${curPath}/${node.name}` : node.name;
+      if (nodePath === path) return false;
+      if (node.children) node.children = walk(node.children, nodePath);
+      return true;
+    });
+  }
+
+  return walk(newTree, "");
+}
+
+export function reconstructTree(
+  nodes: FileNode[],
+  base = "",
+  filesContent: Record<string, string> = {},
+): FileNode[] {
+  return nodes.map((n) => {
+    const path = base ? `${base}/${n.name}` : n.name;
+    if (n.type === "folder") {
+      return {
+        name: n.name,
+        type: "folder",
+        children: n.children
+          ? reconstructTree(n.children, path, filesContent)
+          : [],
+      };
+    }
+    return { name: n.name, type: "file", content: filesContent[path] || "" };
+  });
+}
+
+export function findFirstFile(nodes: FileNode[], base = ""): string | null {
+  for (const node of nodes) {
+    const path = base ? `${base}/${node.name}` : node.name;
+    if (node.type === "file") return path;
+    if (node.children) {
+      const found = findFirstFile(node.children, path);
+      if (found) return found;
+    }
+  }
+  return null;
+}

--- a/app/editor/[id]/utils/fileTreeHelpers.ts
+++ b/app/editor/[id]/utils/fileTreeHelpers.ts
@@ -65,7 +65,11 @@ export function reconstructTree(
           : [],
       };
     }
-    return { name: n.name, type: "file", content: filesContent[path] || "" };
+    return {
+      name: n.name,
+      type: "file",
+      content: n.content || filesContent[path] || "",
+    };
   });
 }
 

--- a/app/editor/[id]/utils/fileTreeHelpers.ts
+++ b/app/editor/[id]/utils/fileTreeHelpers.ts
@@ -3,7 +3,6 @@ import type { FileNode, NodeAddedPayload, NodeDeletedPayload } from "../types";
 export function addNode(
   tree: FileNode[],
   payload: NodeAddedPayload,
-  onFileInit?: (full: string) => void,
 ): FileNode[] {
   const { type, parentPath, name } = payload;
   const newTree = JSON.parse(JSON.stringify(tree)) as FileNode[];
@@ -15,7 +14,6 @@ export function addNode(
         if (!node.children) node.children = [];
         if (type === "file") {
           node.children.push({ name, type: "file" });
-          onFileInit?.(`${nodePath}/${name}`);
         } else {
           node.children.push({ name, type: "folder", children: [] });
         }

--- a/app/editor/[id]/utils/fileTreeHelpers.ts
+++ b/app/editor/[id]/utils/fileTreeHelpers.ts
@@ -14,7 +14,7 @@ export function addNode(
       if (nodePath === parentPath) {
         if (!node.children) node.children = [];
         if (type === "file") {
-          node.children.push({ name, type: "file", content: "" });
+          node.children.push({ name, type: "file" });
           onFileInit?.(`${nodePath}/${name}`);
         } else {
           node.children.push({ name, type: "folder", children: [] });

--- a/app/editor/[id]/utils/monacoSetup.ts
+++ b/app/editor/[id]/utils/monacoSetup.ts
@@ -1,0 +1,55 @@
+import { useEffect } from "react";
+
+export function useMonacoSetup() {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    type MonacoEnv = {
+      MonacoEnvironment?: {
+        getWorker?: (moduleId: string, label: string) => Worker;
+      };
+    };
+
+    const monacoEnv = ((window as MonacoEnv).MonacoEnvironment =
+      (window as MonacoEnv).MonacoEnvironment || {});
+
+    monacoEnv.getWorker = function (_moduleId: string, label: string) {
+      if (label === "json")
+        return new Worker(
+          new URL(
+            "monaco-editor/esm/vs/language/json/json.worker",
+            import.meta.url,
+          ),
+          { type: "module" },
+        );
+      if (label === "css" || label === "scss" || label === "less")
+        return new Worker(
+          new URL(
+            "monaco-editor/esm/vs/language/css/css.worker",
+            import.meta.url,
+          ),
+          { type: "module" },
+        );
+      if (label === "html" || label === "handlebars" || label === "razor")
+        return new Worker(
+          new URL(
+            "monaco-editor/esm/vs/language/html/html.worker",
+            import.meta.url,
+          ),
+          { type: "module" },
+        );
+      if (label === "typescript" || label === "javascript")
+        return new Worker(
+          new URL(
+            "monaco-editor/esm/vs/language/typescript/ts.worker",
+            import.meta.url,
+          ),
+          { type: "module" },
+        );
+      return new Worker(
+        new URL("monaco-editor/esm/vs/editor/editor.worker", import.meta.url),
+        { type: "module" },
+      );
+    };
+  }, []);
+}

--- a/app/editor/[id]/utils/monacoSetup.ts
+++ b/app/editor/[id]/utils/monacoSetup.ts
@@ -10,8 +10,8 @@ export function useMonacoSetup() {
       };
     };
 
-    const monacoEnv = ((window as MonacoEnv).MonacoEnvironment =
-      (window as MonacoEnv).MonacoEnvironment || {});
+    const monacoEnv = (window as MonacoEnv).MonacoEnvironment || {};
+    (window as MonacoEnv).MonacoEnvironment = monacoEnv;
 
     monacoEnv.getWorker = function (_moduleId: string, label: string) {
       if (label === "json")

--- a/app/invitations/page.tsx
+++ b/app/invitations/page.tsx
@@ -3,10 +3,7 @@
 import { useEffect, useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/app/components/ui/button";
-import {
-  Card,
-  CardContent,
-} from "@/app/components/ui/card";
+import { Card, CardContent } from "@/app/components/ui/card";
 import { Badge } from "@/app/components/ui/badge";
 import {
   User,
@@ -214,8 +211,8 @@ export default function InvitationsPage() {
               </div>
               <h3 className="text-xl font-semibold mb-2">No Invitations</h3>
               <p className="text-muted-foreground max-w-sm">
-                When someone invites you to collaborate on a project, you&apos;ll see
-                their invitations here.
+                When someone invites you to collaborate on a project,
+                you&apos;ll see their invitations here.
               </p>
             </div>
           ) : (

--- a/types/y-websocket.d.ts
+++ b/types/y-websocket.d.ts
@@ -1,9 +1,0 @@
-declare module "y-websocket" {
-  import { Doc } from "yjs";
-
-  export class WebsocketProvider {
-    constructor(serverUrl: string, roomName: string, doc: Doc, options?: any);
-    awareness: any;
-    destroy(): void;
-  }
-}


### PR DESCRIPTION
The editor/[id] page had grown large and unwieldy, making it difficult to maintain and scale. This refactoring breaks down the monolithic component into smaller, logically separated pieces to improve readability, maintainability, and testability.

**Key Changes:**
- Extract types to `types/index.ts` for centralized type definitions
- Create utility modules:
  - `utils/fileTreeHelpers.ts` - File tree manipulation functions
  - `utils/colorHelpers.ts` - Color utility functions
  - `utils/monacoSetup.ts` - Monaco editor configuration
- Implement custom hooks:
  - `hooks/useUser.ts` - User authentication state
  - `hooks/useSocket.ts` - Socket.io communication
  - `hooks/useFileTree.ts` - File tree state management
  - `hooks/useYjs.ts` - Yjs and Monaco integration
- Split UI into focused components:
  - `components/FileTree.tsx` - File tree navigation
  - `components/ChatPanel.tsx` - Real-time chat interface
  - `components/PresenceList.tsx` - User presence display
- Simplify main `page.tsx` to act as coordinator using the new hooks and components

**Improvements:**
- Better separation of concerns
- Enhanced reusability of hooks and components
- Improved code organization and readability
- Easier testing and debugging
- More maintainable codebase structure

This refactoring maintains all existing functionality while making the code much more modular and easier to work with.